### PR TITLE
Update for start pulse for DHT sensors

### DIFF
--- a/tasmota/xsns_06_dht.ino
+++ b/tasmota/xsns_06_dht.ino
@@ -83,17 +83,21 @@ bool DhtRead(uint8_t sensor)
   pinMode(Dht[sensor].pin, OUTPUT);
   digitalWrite(Dht[sensor].pin, LOW);
 
-  if (GPIO_SI7021 == Dht[sensor].type) {
-    delayMicroseconds(500);
-  } else {
-    delay(20);
+  // Different sensors use different start pulse length
+  switch (Dht[sensor].type) {
+    case GPIO_DHT22:
+      delayMicroseconds(1100);  // Datasheet says 'at least 1ms'
+    case GPIO_SI7021:
+      delayMicroseconds(500);
+      break;
+    default:
+      delay(20);  // DHT11 requires 20ms.
   }
-
-  noInterrupts();
-  digitalWrite(Dht[sensor].pin, HIGH);
-  delayMicroseconds(40);
+  
+  // release pin so device can respond
   pinMode(Dht[sensor].pin, INPUT_PULLUP);
-  delayMicroseconds(10);
+  delayMicroseconds(40);
+  
   if (-1 == DhtExpectPulse(sensor, LOW)) {
     AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DHT D_TIMEOUT_WAITING_FOR " " D_START_SIGNAL_LOW " " D_PULSE));
     error = 1;


### PR DESCRIPTION
Datasheet for DHT22 / AM2302 shows 'min 1ms' rather than 20ms required for DHT11.  Also changing from pulling the pin high to releasing it to INPUT_PULLUP per thread on issue #5619  This is not a complete fix for that issue as it appears to be device 'brand' related but it does improve reliability of DHT22's in testing on WemosD1 and ESP01 devices I had to hand.  DHT11 tested as well.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR.
  - [ x] The code change is tested and works on core 2.6.1
  - [x ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
